### PR TITLE
Raise custom error on CoffeeScript compile fail.

### DIFF
--- a/lib/stitch/compilers/coffeescript.rb
+++ b/lib/stitch/compilers/coffeescript.rb
@@ -12,6 +12,8 @@ module Stitch
     def compile(path)
       source = File.read(path)
       CoffeeScript.compile(source)
+    rescue => e
+      raise RuntimeError, "#{path}: #{e}", ''
     end
   end
 end

--- a/lib/stitch/compilers/coffeescript.rb
+++ b/lib/stitch/compilers/coffeescript.rb
@@ -11,9 +11,7 @@ module Stitch
     
     def compile(path)
       source = File.read(path)
-      CoffeeScript.compile(source)
-    rescue => e
-      raise "#{path}: #{e}"
+      CoffeeScript.compile(source, :filename => path.to_s)
     end
   end
 end

--- a/lib/stitch/compilers/coffeescript.rb
+++ b/lib/stitch/compilers/coffeescript.rb
@@ -13,7 +13,7 @@ module Stitch
       source = File.read(path)
       CoffeeScript.compile(source)
     rescue => e
-      raise RuntimeError, "#{path}: #{e}", ''
+      raise "#{path}: #{e}"
     end
   end
 end


### PR DESCRIPTION
Shows the filename in the backtrace when you have a CoffeeScript error.

Before:

ERROR: Stitching  failed: too many ) on line 66

After:

ERROR: Stitching  failed: app/assets/javascripts/web/views.coffee: too many ) on line 66

(when using guard-stitch)
