### PR TITLE
Added `excludes` option to exclude directories or files which exist under `paths`.

### DIFF
--- a/lib/stitch/package.rb
+++ b/lib/stitch/package.rb
@@ -6,7 +6,8 @@ module Stitch
       :identifier   => "require",
       :paths        => [],
       :files        => [],
-      :dependencies => []
+      :dependencies => [],
+      :excludes     => []
     }
 
     def initialize(options = {})
@@ -17,6 +18,7 @@ module Stitch
       @files        = Array(options[:files])
       @root         = options[:root]
       @dependencies = Array(options[:dependencies])
+      @excludes     = Array(options[:excludes])
     end
 
     def compile
@@ -34,7 +36,7 @@ module Stitch
 
       def compile_sources
         sources = @paths.map {|path|
-          Source.from_path(path)
+          Source.from_path(path, nil, [], @excludes)
         }.flatten
 
         sources |= @files.map {|file|

--- a/lib/stitch/source.rb
+++ b/lib/stitch/source.rb
@@ -6,13 +6,19 @@ module Stitch
     # Usage:
     #   sources = Source.from_path("./app")
     #
-    def self.from_path(root, path = nil, result = [])
+    def self.from_path(root, path = nil, result = [], excludes = [])
       path ||= root
       path = Pathname.new(path)
 
+      for exclude in excludes
+        if path.to_s === exclude
+          return
+        end
+      end
+
       if path.directory?
         path.children.each do |child|
-          from_path(root, child, result)
+          from_path(root, child, result, excludes)
         end
       else
         source = self.new(root, path)


### PR DESCRIPTION
Usage:

``` ruby
Stitch::Package.new(:paths => ["app"], excludes: => ["app/spec", "app/experimental/features.coffee"], dependencies => ["lib/jquery.js"]).compile
```
